### PR TITLE
Eliminate global logging

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -72,6 +72,14 @@
   version = "v4.2.0"
 
 [[projects]]
+  digest = "1:edd2fa4578eb086265db78a9201d15e76b298dfd0d5c379da83e9c61712cf6df"
+  name = "github.com/go-logr/logr"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "9fb12b3b21c5415d16ac18dc5cd42c1cfdd40c4e"
+  version = "v0.1.0"
+
+[[projects]]
   digest = "1:4d02824a56d268f74a6b6fdd944b20b58a77c3d70e81008b3ee0c4f1a6777340"
   name = "github.com/gogo/protobuf"
   packages = [
@@ -600,6 +608,7 @@
   input-imports = [
     "github.com/blang/semver",
     "github.com/evanphx/json-patch",
+    "github.com/go-logr/logr",
     "github.com/pkg/errors",
     "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -21,3 +21,6 @@
 [[constraint]]
   name = "k8s.io/client-go"
   version = "kubernetes-1.13.1"
+[[constraint]]
+  name = "github.com/go-logr/logr"
+  version = "0.1.0"

--- a/pkg/logging/logrus_logr.go
+++ b/pkg/logging/logrus_logr.go
@@ -1,0 +1,70 @@
+// Copyright 2019 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package logging
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/sirupsen/logrus"
+)
+
+type logrusAdapter struct {
+	l *logrus.Entry
+}
+
+func NewLogrusLoggerAdapter(l *logrus.Logger) logr.Logger {
+	return NewLogrusEntryAdapter(logrus.NewEntry(l))
+}
+
+func NewLogrusEntryAdapter(e *logrus.Entry) logr.Logger {
+	return &logrusAdapter{
+		l: e,
+	}
+}
+
+func (l *logrusAdapter) withFields(keysAndValues []interface{}) *logrus.Entry {
+	if len(keysAndValues)%2 != 0 {
+		panic("programmer error - must have an even number of keysAndValues")
+	}
+
+	fields := make(logrus.Fields, len(keysAndValues)/2)
+	for i := 0; i < len(keysAndValues); i += 2 {
+		k, v := keysAndValues[i], keysAndValues[i+1]
+		fields[k.(string)] = v
+	}
+
+	return l.l.WithFields(fields)
+}
+
+func (l *logrusAdapter) Info(msg string, keysAndValues ...interface{}) {
+	l.withFields(keysAndValues).Info(msg)
+}
+
+func (l *logrusAdapter) Enabled() bool {
+	// Don't try to distinguish between info, debug, trace as far as V() levels go
+	return true
+}
+
+func (l *logrusAdapter) Error(err error, msg string, keysAndValues ...interface{}) {
+	l.withFields(keysAndValues).WithError(err).Error(msg)
+}
+
+func (l *logrusAdapter) V(level int) logr.InfoLogger {
+	panic("not implemented")
+}
+
+func (l *logrusAdapter) WithValues(keysAndValues ...interface{}) logr.Logger {
+	return NewLogrusEntryAdapter(l.withFields(keysAndValues))
+}
+
+const nameKey = "logger"
+
+func (l *logrusAdapter) WithName(name string) logr.Logger {
+	if existing := l.l.Data[nameKey]; existing != "" {
+		return l.WithValues(nameKey, fmt.Sprintf("%s.%s", existing, name))
+	}
+
+	return l.WithValues(nameKey, name)
+}

--- a/pkg/upgrade/key_pair.go
+++ b/pkg/upgrade/key_pair.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -44,7 +43,6 @@ func (k *keyPairGetter) getKeyPair(cluster *clusterapiv1alpha1.Cluster, config K
 }
 
 func getEmbeddedKeyPair(cluster *clusterapiv1alpha1.Cluster, path string) (*KeyPair, error) {
-	logrus.Infof("getEmbeddedKeyPair, path=%s", path)
 	pathParts := strings.Split(path, ".")
 	certPath := append(pathParts, "cert")
 	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cluster)
@@ -83,7 +81,6 @@ func getEmbeddedKeyPair(cluster *clusterapiv1alpha1.Cluster, path string) (*KeyP
 }
 
 func (k *keyPairGetter) getSecretRefKeyPair(secretNamespace, secretName string) (*KeyPair, error) {
-	logrus.Infof("getSecretKeyPair, name=%s/%s", secretNamespace, secretName)
 	secret, err := k.secretClient.Secrets(secretNamespace).Get(secretName, metav1.GetOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "error retrieving key pair secret ref")

--- a/vendor/github.com/go-logr/logr/LICENSE
+++ b/vendor/github.com/go-logr/logr/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/go-logr/logr/README.md
+++ b/vendor/github.com/go-logr/logr/README.md
@@ -1,0 +1,36 @@
+# A more minimal logging API for Go
+
+Before you consider this package, please read [this blog post by the inimitable
+Dave Cheney](http://dave.cheney.net/2015/11/05/lets-talk-about-logging).  I
+really appreciate what he has to say, and it largely aligns with my own
+experiences.  Too many choices of levels means inconsistent logs.
+
+This package offers a purely abstract interface, based on these ideas but with
+a few twists.  Code can depend on just this interface and have the actual
+logging implementation be injected from callers.  Ideally only `main()` knows
+what logging implementation is being used.
+
+# Differences from Dave's ideas
+
+The main differences are:
+
+1) Dave basically proposes doing away with the notion of a logging API in favor
+of `fmt.Printf()`.  I disagree, especially when you consider things like output
+locations, timestamps, file and line decorations, and structured logging.  I
+restrict the API to just 2 types of logs: info and error.
+
+Info logs are things you want to tell the user which are not errors.  Error
+logs are, well, errors.  If your code receives an `error` from a subordinate
+function call and is logging that `error` *and not returning it*, use error
+logs.
+
+2) Verbosity-levels on info logs.  This gives developers a chance to indicate
+arbitrary grades of importance for info logs, without assigning names with
+semantic meaning such as "warning", "trace", and "debug".  Superficially this
+may feel very similar, but the primary difference is the lack of semantics.
+Because verbosity is a numerical value, it's safe to assume that an app running
+with higher verbosity means more (and less important) logs will be generated.
+
+This is a BETA grade API.  I have implemented it for
+[glog](https://godoc.org/github.com/golang/glog). Until there is a significant
+2nd implementation, I don't really know how it will change.

--- a/vendor/github.com/go-logr/logr/logr.go
+++ b/vendor/github.com/go-logr/logr/logr.go
@@ -1,0 +1,151 @@
+// Package logr defines abstract interfaces for logging.  Packages can depend on
+// these interfaces and callers can implement logging in whatever way is
+// appropriate.
+//
+// This design derives from Dave Cheney's blog:
+//     http://dave.cheney.net/2015/11/05/lets-talk-about-logging
+//
+// This is a BETA grade API.  Until there is a significant 2nd implementation,
+// I don't really know how it will change.
+//
+// The logging specifically makes it non-trivial to use format strings, to encourage
+// attaching structured information instead of unstructured format strings.
+//
+// Usage
+//
+// Logging is done using a Logger.  Loggers can have name prefixes and named values
+// attached, so that all log messages logged with that Logger have some base context
+// associated.
+//
+// The term "key" is used to refer to the name associated with a particular value, to
+// disambiguate it from the general Logger name.
+//
+// For instance, suppose we're trying to reconcile the state of an object, and we want
+// to log that we've made some decision.
+//
+// With the traditional log package, we might write
+//  log.Printf(
+//      "decided to set field foo to value %q for object %s/%s",
+//       targetValue, object.Namespace, object.Name)
+//
+// With logr's structured logging, we'd write
+//  // elsewhere in the file, set up the logger to log with the prefix of "reconcilers",
+//  // and the named value target-type=Foo, for extra context.
+//  log := mainLogger.WithName("reconcilers").WithValues("target-type", "Foo")
+//
+//  // later on...
+//  log.Info("setting field foo on object", "value", targetValue, "object", object)
+//
+// Depending on our logging implementation, we could then make logging decisions based on field values
+// (like only logging such events for objects in a certain namespace), or copy the structured
+// information into a structured log store.
+//
+// For logging errors, Logger has a method called Error.  Suppose we wanted to log an
+// error while reconciling.  With the traditional log package, we might write
+//   log.Errorf("unable to reconcile object %s/%s: %v", object.Namespace, object.Name, err)
+//
+// With logr, we'd instead write
+//   // assuming the above setup for log
+//   log.Error(err, "unable to reconcile object", "object", object)
+//
+// This functions similarly to:
+//   log.Info("unable to reconcile object", "error", err, "object", object)
+//
+// However, it ensures that a standard key for the error value ("error") is used across all
+// error logging.  Furthermore, certain implementations may choose to attach additional
+// information (such as stack traces) on calls to Error, so it's preferred to use Error
+// to log errors.
+//
+// Parts of a log line
+//
+// Each log message from a Logger has four types of context:
+// logger name, log verbosity, log message, and the named values.
+//
+// The Logger name constists of a series of name "segments" added by successive calls to WithName.
+// These name segments will be joined in some way by the underlying implementation.  It is strongly
+// reccomended that name segements contain simple identifiers (letters, digits, and hyphen), and do
+// not contain characters that could muddle the log output or confuse the joining operation (e.g.
+// whitespace, commas, periods, slashes, brackets, quotes, etc).
+//
+// Log verbosity represents how little a log matters.  Level zero, the default, matters most.
+// Increasing levels matter less and less.  Try to avoid lots of different verbosity levels,
+// and instead provide useful keys, logger names, and log messages for users to filter on.
+// It's illegal to pass a log level below zero.
+//
+// The log message consists of a constant message attached to the the log line.  This
+// should generally be a simple description of what's occuring, and should never be a format string.
+//
+// Variable information can then be attached using named values (key/value pairs).  Keys are arbitrary
+// strings, while values may be any Go value.
+//
+// Key Naming Conventions
+//
+// While users are generally free to use key names of their choice, it's generally best to avoid
+// using the following keys, as they're frequently used by implementations:
+//
+// - `"error"`: the underlying error value in the `Error` method.
+// - `"stacktrace"`: the stack trace associated with a particular log line or error
+//                   (often from the `Error` message).
+// - `"caller"`: the calling information (file/line) of a particular log line.
+// - `"msg"`: the log message.
+// - `"level"`: the log level.
+// - `"ts"`: the timestamp for a log line.
+//
+// Implementations are encouraged to make use of these keys to represent the above
+// concepts, when neccessary (for example, in a pure-JSON output form, it would be
+// necessary to represent at least message and timestamp as ordinary named values).
+package logr
+
+// TODO: consider adding back in format strings if they're really needed
+// TODO: consider other bits of zap/zapcore functionality like ObjectMarshaller (for arbitrary objects)
+// TODO: consider other bits of glog functionality like Flush, InfoDepth, OutputStats
+
+// InfoLogger represents the ability to log non-error messages, at a particular verbosity.
+type InfoLogger interface {
+	// Info logs a non-error message with the given key/value pairs as context.
+	//
+	// The msg argument should be used to add some constant description to
+	// the log line.  The key/value pairs can then be used to add additional
+	// variable information.  The key/value pairs should alternate string
+	// keys and arbitrary values.
+	Info(msg string, keysAndValues ...interface{})
+
+	// Enabled tests whether this InfoLogger is enabled.  For example,
+	// commandline flags might be used to set the logging verbosity and disable
+	// some info logs.
+	Enabled() bool
+}
+
+// Logger represents the ability to log messages, both errors and not.
+type Logger interface {
+	// All Loggers implement InfoLogger.  Calling InfoLogger methods directly on
+	// a Logger value is equivalent to calling them on a V(0) InfoLogger.  For
+	// example, logger.Info() produces the same result as logger.V(0).Info.
+	InfoLogger
+
+	// Error logs an error, with the given message and key/value pairs as context.
+	// It functions similarly to calling Info with the "error" named value, but may
+	// have unique behavior, and should be preferred for logging errors (see the
+	// package documentations for more information).
+	//
+	// The msg field should be used to add context to any underlying error,
+	// while the err field should be used to attach the actual error that
+	// triggered this log line, if present.
+	Error(err error, msg string, keysAndValues ...interface{})
+
+	// V returns an InfoLogger value for a specific verbosity level.  A higher
+	// verbosity level means a log message is less important.  It's illegal to
+	// pass a log level less than zero.
+	V(level int) InfoLogger
+
+	// WithValues adds some key-value pairs of context to a logger.
+	// See Info for documentation on how key/value pairs work.
+	WithValues(keysAndValues ...interface{}) Logger
+
+	// WithName adds a new element to the logger's name.
+	// Successive calls with WithName continue to append
+	// suffixes to the logger's name.  It's strongly reccomended
+	// that name segments contain only letters, digits, and hyphens
+	// (see the package documentation for more information).
+	WithName(name string) Logger
+}


### PR DESCRIPTION
Remove all global logging calls to logrus.*.

Pull in go-logr as our logging interface.

Add a logrus implementation for go-logr.

Signed-off-by: Andy Goldstein <goldsteina@vmware.com>

Fixes #11