### PR TITLE
Support upgrading etcd 3.2 / Kube 1.13

### DIFF
--- a/pkg/upgrade/control_plane_test.go
+++ b/pkg/upgrade/control_plane_test.go
@@ -40,8 +40,8 @@ func TestEtcdMemberHealthStructDecoding(t *testing.T) {
 
 	expected := etcdMembersResponse{
 		Members: []etcdMember{
-			{Name: "two", ID: 5782640540428238474},
-			{Name: "default", ID: 10276657743932975437},
+			{Name: "two", ID: 5782640540428238474, ClientURLs: []string{"http://localhost:3379"}},
+			{Name: "default", ID: 10276657743932975437, ClientURLs: []string{"http://localhost:2379"}},
 		},
 	}
 


### PR DESCRIPTION
Use --endpoints instead of --cluster for 'etcdctl endpoint health'
because --cluster is only available in etcd 3.3 and newer, but kubeadm
installs etcd 3.2 for Kubernetes v1.13.x.

Fixes #51 

Signed-off-by: Andy Goldstein <goldsteina@vmware.com>