### PR TITLE
Fix kubeconfig secret key name

### DIFF
--- a/pkg/upgrade/key_pair.go
+++ b/pkg/upgrade/key_pair.go
@@ -19,7 +19,7 @@ import (
 )
 
 // kubeconfigSecretKey is the key where the kubeconfig is stored in the secret.
-const kubeconfigSecretKey = "kubeconfig"
+const kubeconfigSecretKey = "value"
 
 // keyPair contains a cert and key.
 type keyPair struct {


### PR DESCRIPTION
We assumed it would be 'kubeconfig', but CAPI v0.1.4 uses 'value', so
this switches our const to 'value'.

Signed-off-by: Andy Goldstein <goldsteina@vmware.com>