### PR TITLE
Edit kubeadm ConfigMap for control plane upgrades

### DIFF
--- a/main.go
+++ b/main.go
@@ -111,7 +111,5 @@ func upgradeCluster(config upgrade.Config) error {
 		return err
 	}
 
-	infoMessage := fmt.Sprintf("Rerun with `--upgrade-id=%s` if this upgrade fails midway and you want to retry", config.UpgradeID)
-	log.Info(infoMessage)
 	return upgrader.Upgrade()
 }

--- a/pkg/upgrade/base.go
+++ b/pkg/upgrade/base.go
@@ -97,6 +97,9 @@ func newBase(log logr.Logger, config Config) (*base, error) {
 		config.UpgradeID = fmt.Sprintf("%d", time.Now().Unix())
 	}
 
+	infoMessage := fmt.Sprintf("Rerun with `--upgrade-id=%s` if this upgrade fails midway and you want to retry", config.UpgradeID)
+	log.Info(infoMessage)
+
 	return &base{
 		log:                        log,
 		userVersion:                userVersion,


### PR DESCRIPTION
When a new control plane node joins the cluster, it gets the version to
use as the image tag for the static pod manifests from the
kubeadm-config ConfigMap in the kube-system namespace. We must change
the ClusterConfiguration.kubernetesVersion to match the desired version,
then upload the updated ConfigMap before proceeding to create any new
machines.

Signed-off-by: Andy Goldstein <goldsteina@vmware.com>

Fixes #56 