### PR TITLE
Make the kubeconfig argument not required

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,8 +40,7 @@ func main() {
 	}
 
 	root.Flags().StringVar(&upgradeConfig.ManagementCluster.Kubeconfig, "kubeconfig",
-		"", "The kubeconfig path for the management cluster (required)")
-	root.MarkFlagRequired("kubeconfig")
+		"", "The kubeconfig path for the management cluster")
 
 	root.Flags().StringVar(&upgradeConfig.TargetCluster.Namespace,
 		"cluster-namespace", "", "The namespace of target cluster (required)")


### PR DESCRIPTION
Make the `kubeconfig` argument not required which allows us to fall back to an in-cluster client configuration.

closes #70

Signed-off-by: Andrew Williams <andrewwi@vmware.com>