### PR TITLE
Fix AMI JSONPatch examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ targetCluster:
 kubernetesVersion: v1.15.3
 upgradeID: 1234
 patches:
-  infrastructure: '[{ "op": "replace", "path": "/spec/ami", "value": "ami-123456789" }]'
+  infrastructure: '[{ "op": "replace", "path": "/spec/ami/id", "value": "ami-123456789" }]'
 ```
 
 Run an upgrade with the following command:
@@ -104,7 +104,7 @@ bootstrap resources. An example use for this could be to change the image ID in 
 machine resource. For example, to change the AMI for an `AWSMachine` for the AWS provider, you would use the following:
 
 ```
-[{ "op": "replace", "path": "/spec/ami", "value": "ami-123456789" }]
+[{ "op": "replace", "path": "/spec/ami/id", "value": "ami-123456789" }]
 ```
 
 When specifying patches, make sure you do not replace an entire field such as `metadata` or `spec` unless you include


### PR DESCRIPTION
This makes a small adjustment to the examples for patching the AMI field. In v1alpha2, AMI's are now a `AWSResourceReference` object instead of a string. Meaning we need to patch the `id` field now.

https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/2f2c8dabbe81ffff6af5075e2c265c82577d9420/api/v1alpha2/types.go#L30-L33
