### PR TITLE
clear replacement machine status to ensure no matches to previous machines

### DIFF
--- a/pkg/upgrade/control_plane.go
+++ b/pkg/upgrade/control_plane.go
@@ -458,6 +458,9 @@ func (u *ControlPlaneUpgrader) updateMachine(replacementKey ctrlclient.ObjectKey
 		desiredVersion := u.desiredVersion.String()
 		replacementMachine.Spec.Version = &desiredVersion
 
+		// clear status to ensure the provider can't match the new machine to any existing machine
+		replacementMachine.Status = clusterv1.MachineStatus{}
+
 		log.Info("Creating new machine")
 		if err := u.managementClusterClient.Create(context.TODO(), replacementMachine); err != nil {
 			return errors.Wrapf(err, "Error creating machine: %s", replacementMachine.Name)


### PR DESCRIPTION
CAPV doesn't actually provision a new machine based on the copied replacement machine because it assumes one already exists by checking the machine status. Machine status should be cleared anyways given everything in status is specific to the previously copied machine.

Signed-off-by: Andrew Sy Kim <kiman@vmware.com>