### PR TITLE
Use machine timeout for deletions too

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Both JSON and YAML formats are supported.
 
 ```
 Usage:
-  ./bin/cluster-api-upgrade-tool [flags]
+  cluster-api-upgrade-tool [flags]
 
 Flags:
       --bootstrap-patches string        JSON patch expression of patches to apply to the machine's bootstrap resource (optional)
@@ -93,7 +93,7 @@ Flags:
       --infrastructure-patches string   JSON patch expression of patches to apply to the machine's infrastructure resource (optional)
       --kubeconfig string               The kubeconfig path for the management cluster
       --kubernetes-version string       Desired kubernetes version to upgrade to (required)
-      --machine-timeout duration        How long to wait for a new Machine to be ready (default 15m0s)
+      --machine-timeout duration        How long to wait for machine operations (create, delete) to complete (default 15m0s)
       --upgrade-id string               Unique identifier used to resume a partial upgrade (required)
 ```
 

--- a/main.go
+++ b/main.go
@@ -134,7 +134,7 @@ func main() {
 		&configFromFlags.MachineTimeout.Duration,
 		"machine-timeout",
 		configFromFlags.MachineTimeout.Duration,
-		"How long to wait for a new Machine to be ready",
+		"How long to wait for machine operations (create, delete) to complete",
 	)
 
 	if err := root.Execute(); err != nil {

--- a/pkg/upgrade/control_plane.go
+++ b/pkg/upgrade/control_plane.go
@@ -503,12 +503,10 @@ func (u *ControlPlaneUpgrader) updateMachine(replacementKey ctrlclient.ObjectKey
 		}
 	}
 
-	const (
-		deleteMachineInterval = 10 * time.Second
-		deleteMachineTimeout  = 5 * time.Minute
-	)
+	const deleteMachineInterval = 10 * time.Second
+
 	log.Info("Deleting existing machine")
-	err = wait.PollImmediate(deleteMachineInterval, deleteMachineTimeout, func() (bool, error) {
+	err = wait.PollImmediate(deleteMachineInterval, u.machineTimeout, func() (bool, error) {
 		// TODO plumb a context down to here instead of using TODO
 		if err := u.managementClusterClient.Delete(context.TODO(), machine); err != nil {
 			log.Error(err, "error deleting machine")
@@ -521,7 +519,7 @@ func (u *ControlPlaneUpgrader) updateMachine(replacementKey ctrlclient.ObjectKey
 	}
 
 	log.Info("Waiting for machine to be deleted")
-	err = wait.PollImmediate(deleteMachineInterval, deleteMachineTimeout, func() (bool, error) {
+	err = wait.PollImmediate(deleteMachineInterval, u.machineTimeout, func() (bool, error) {
 		// TODO plumb a context down to here instead of using TODO
 		var tempMachine clusterv1.Machine
 		key := ctrlclient.ObjectKey{
@@ -539,7 +537,7 @@ func (u *ControlPlaneUpgrader) updateMachine(replacementKey ctrlclient.ObjectKey
 
 	// remove node from apiEndpoints in Kubeadm config map
 	log.Info("Removing machine from kubeadm ConfigMap")
-	err = wait.PollImmediate(deleteMachineInterval, deleteMachineTimeout, func() (bool, error) {
+	err = wait.PollImmediate(deleteMachineInterval, u.machineTimeout, func() (bool, error) {
 		if err := u.updateKubeadmConfigMap(func(in *v1.ConfigMap) (*v1.ConfigMap, error) {
 			return removeNodeFromKubeadmConfigMapClusterStatusAPIEndpoints(in, oldHostName)
 		}); err != nil {


### PR DESCRIPTION
Use the machine timeout flag/config setting for machine deletions, as
the hard-coded 5 minute timout was not always sufficient.

Fixes #140 