### PR TITLE
Remove .upgrade. from machine names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	k8s.io/api v0.0.0-20190918195907-bd6ac527cfd2
 	k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d
 	k8s.io/client-go v0.0.0-20190918200256-06eb1244587a
+	k8s.io/utils v0.0.0-20190809000727-6c36bc71fc4a
 	sigs.k8s.io/cluster-api v0.2.6
 	sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm v0.1.4
 	sigs.k8s.io/controller-runtime v0.3.0

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -4,13 +4,11 @@ go 1.12
 
 require (
 	cloud.google.com/go v0.38.0 // indirect
-	github.com/grpc-ecosystem/grpc-gateway v1.8.5 // indirect
 	github.com/onsi/ginkgo v1.10.1
 	github.com/onsi/gomega v1.7.0
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/vmware/cluster-api-upgrade-tool v0.1.0
-	google.golang.org/grpc v1.19.1 // indirect
 	k8s.io/api v0.0.0-20190918195907-bd6ac527cfd2
 	k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible


### PR DESCRIPTION
Forcing replacment machine names to include ".upgrade." was breaking
some Cluster API providers that map the machine name directly to the
instance's hostname. This change removes that hardcoding and replaces it
with a single dash followed by whatever the user specifies for the
upgrade ID. Additionally, it keeps track of the "base name" of a
machine in an annotation, and uses that to generate the replacement
machine name instead of trying to search for a special suffix. This
means, for example, that a machine named "cp-0" can have an upgrade ID
of "0": the new name is cp-0-0, and the upgrade tool correctly handles
this now.

I have tested this and it appears to work, but we might want to test it more before merging.

Fixes #146 
Fixes #138

No rush on getting this reviewed & merged - can wait until after the new year.