### PR TITLE
Reconcile bad replacement

### DIFF
--- a/pkg/upgrade/control_plane_test.go
+++ b/pkg/upgrade/control_plane_test.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha2"
@@ -207,6 +208,9 @@ func TestShouldSkipMachine(t *testing.T) {
 		},
 	}
 
+	missingAnnotations := valid.DeepCopy()
+	missingAnnotations.Annotations = make(map[string]string)
+
 	missingProviderID := valid.DeepCopy()
 	missingProviderID.Spec.ProviderID = nil
 
@@ -233,6 +237,11 @@ func TestShouldSkipMachine(t *testing.T) {
 		machine    *clusterv1.Machine
 		expectSkip bool
 	}{
+		{
+			name:       "missing annotations",
+			machine:    missingAnnotations,
+			expectSkip: true,
+		},
 		{
 			name:       "missing provider id",
 			machine:    missingProviderID,
@@ -279,10 +288,11 @@ func TestShouldSkipMachine(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			u := &ControlPlaneUpgrader{
 				upgradeID: "abc",
+				log:       log.NullLogger{},
 			}
 
 			if e, a := tc.expectSkip, u.shouldSkipMachine(log.NullLogger{}, tc.machine); e != a {
-				t.Errorf("got %t, wanted %t", e, a)
+				t.Errorf("expected %t, got %t", e, a)
 			}
 		})
 	}
@@ -390,5 +400,121 @@ kind: ClusterStatus
 
 	if e, a := expectedCM.Data["ClusterStatus"], updatedCM.Data["ClusterStatus"]; e != a {
 		t.Errorf("expected %s, got %s", e, a)
+	}
+}
+
+func TestHasNodeLabel(t *testing.T) {
+	nodeWithLabel := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+			Labels: map[string]string{
+				LabelNodeRoleMaster: "",
+			},
+		},
+	}
+	nodeWithoutLabel := nodeWithLabel.DeepCopy()
+	nodeWithoutLabel.SetLabels(make(map[string]string))
+
+	tests := []struct {
+		name     string
+		node     *corev1.Node
+		expected bool
+	}{
+		{
+			name:     "node has label",
+			node:     nodeWithLabel,
+			expected: true,
+		},
+		{
+			name:     "node is not found",
+			node:     nil,
+			expected: false,
+		},
+		{
+			name:     "node does not have label",
+			node:     nodeWithoutLabel,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var fakeClient *fake.Clientset
+
+			if tt.node != nil {
+				fakeClient = fake.NewSimpleClientset(tt.node)
+			} else {
+				fakeClient = fake.NewSimpleClientset()
+			}
+			u := &ControlPlaneUpgrader{
+				log:                    log.NullLogger{},
+				targetKubernetesClient: fakeClient,
+				upgradeID:              "abc",
+			}
+
+			actual := u.hasMasterNodeLabel("foo")
+			if tt.expected != actual {
+				t.Errorf("expected %t, got %t", tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestIsReplacementMachine(t *testing.T) {
+	upgradeID := "foobar"
+	tests := []struct {
+		name     string
+		machine  *clusterv1.Machine
+		expected bool
+	}{
+		{
+			name: "machine is a replacement",
+			machine: &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cp-0-foobar",
+					Annotations: map[string]string{
+						AnnotationUpgradeID:       upgradeID,
+						AnnotationMachineNameBase: "cp-0",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "machine is an original control plane machine",
+			machine: &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cp-0",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "machine belongs to a different upgrade",
+			machine: &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cp-0-another-upgrade",
+					Annotations: map[string]string{
+						AnnotationUpgradeID:       upgradeID,
+						AnnotationMachineNameBase: "cp-0",
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := &ControlPlaneUpgrader{
+				log:       log.NullLogger{},
+				upgradeID: upgradeID,
+			}
+
+			actual := u.isReplacementMachine(tt.machine)
+			if actual != tt.expected {
+				t.Errorf("expected %t, but got %t", tt.expected, actual)
+			}
+		})
 	}
 }


### PR DESCRIPTION
A few things I would like feedback on:

- Verify logs are sufficient and have appropriate tags
- Verify context timeouts and other wait timeouts are sufficient and will not prolong an upgrade process
- I moved `reconcileMachineAnnotations` to run before reconciling replacement machines as well. After a few test runs, it doesn't look like it has any negative side-effects.
- In the `removeMachine` method, I changed the order of removal. Not sure if this matters. From:
  1. delete the EtcdMember
  1. remove existing Machine
  1. remove machine from kubeadm configmap

- to:
  1. remove existing Machine
  1. delete the EtcdMember
  1. remove machine from kubeadm configmap


Fixes #149 