### PR TITLE
Delete machine for no node

### DIFF
--- a/pkg/upgrade/control_plane.go
+++ b/pkg/upgrade/control_plane.go
@@ -161,7 +161,11 @@ func NewControlPlaneUpgrader(log logr.Logger, config Config) (*ControlPlaneUpgra
 		}
 	}
 
-	log.Info(fmt.Sprintf("Running upgrade with following configuration: %+v", config))
+	jsonConfig, err := json.Marshal(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to json marshal config object")
+	}
+	log.Info(fmt.Sprintf("Running upgrade with following configuration: %s", jsonConfig))
 
 	return &ControlPlaneUpgrader{
 		log:                     log,


### PR DESCRIPTION
In the event that there is a machine object with a provider ID but a
node object from the workload cluster is not found, we want to go ahead
and remove the machine object anyways.
We are just going to skip the step of removing the node reference from
the etcd member lis