### PR TITLE
Fall back to 127.0.0.1 in etcdctl commands when etcd pod has no IP

### DIFF
--- a/pkg/upgrade/control_plane.go
+++ b/pkg/upgrade/control_plane.go
@@ -1184,7 +1184,7 @@ func (u *ControlPlaneUpgrader) etcdctlForPod(ctx context.Context, pod *v1.Pod, a
 
 	ip := pod.Status.PodIP
 	if ip == "" {
-		ip = "[127.0.0.1]"
+		ip = "127.0.0.1"
 	}
 	endpoint := fmt.Sprintf("https://%s:2379", ip)
 

--- a/pkg/upgrade/control_plane.go
+++ b/pkg/upgrade/control_plane.go
@@ -1182,7 +1182,11 @@ func (u *ControlPlaneUpgrader) etcdctl(ctx context.Context, args ...string) (str
 func (u *ControlPlaneUpgrader) etcdctlForPod(ctx context.Context, pod *v1.Pod, args ...string) (string, string, error) {
 	u.log.Info("Running etcdctl", "pod", pod.Name, "args", strings.Join(args, " "))
 
-	endpoint := fmt.Sprintf("https://%s:2379", pod.Status.PodIP)
+	ip := pod.Status.PodIP
+	if ip == "" {
+		ip = "[127.0.0.1]"
+	}
+	endpoint := fmt.Sprintf("https://%s:2379", ip)
 
 	fullArgs := []string{
 		"ETCDCTL_API=3",


### PR DESCRIPTION
In certain environments the etcd pod will lack an IP address. When this
occurs, we can fall back on talking to the loopback address in the
etcdctl commands.

Fixes #161 