### PR TITLE
Remove only the OwnerReferences of kind "Machine"

### DIFF
--- a/pkg/upgrade/control_plane.go
+++ b/pkg/upgrade/control_plane.go
@@ -878,7 +878,7 @@ func generateReplacementMachineName(base, upgradeID string) string {
 func filterOutMachineOwners(ownerRefs []metav1.OwnerReference) []metav1.OwnerReference {
 	filtered := make([]metav1.OwnerReference, 0, len(ownerRefs))
 	for _, owner := range ownerRefs {
-		if owner.Kind == "Machine" {
+		if owner.APIVersion == clusterv1.GroupVersion.String() && owner.Kind == "Machine" {
 			continue
 		}
 		filtered = append(filtered, owner)

--- a/pkg/upgrade/control_plane_test.go
+++ b/pkg/upgrade/control_plane_test.go
@@ -148,7 +148,7 @@ metadata:
 
 func TestMachineOwnerFiltration(t *testing.T) {
 	machineRef := metav1.OwnerReference{
-		APIVersion: "cluster.x-k8s.io/v1alpha2",
+		APIVersion: clusterv1.GroupVersion.String(),
 		Kind:       "Machine",
 		Name:       "Someone",
 		UID:        "abcdefg",


### PR DESCRIPTION
This will preserve owner references that stem from other objects.

Fixes #159 