### PR TITLE
Added Machine patch option

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,6 +117,13 @@ func main() {
 	)
 
 	root.Flags().StringVar(
+		&configFromFlags.Patches.Machine,
+		"machine-patches",
+		"",
+		"JSON patch expression of patches to apply to the machine (optional)",
+	)
+
+	root.Flags().StringVar(
 		&configFromFlags.Patches.Infrastructure,
 		"infrastructure-patches",
 		"",

--- a/pkg/upgrade/config.go
+++ b/pkg/upgrade/config.go
@@ -33,6 +33,7 @@ type TargetClusterConfig struct {
 // PatchConfig contains JSON patch documents for modifying a Machine's referenced infrastructure and bootstrap
 // resources.
 type PatchConfig struct {
+	Machine          string `json:"machine"`
 	Infrastructure   string `json:"infrastructure"`
 	Bootstrap        string `json:"bootstrap"`
 	KubeadmConfigMap string `json:"kubeadmConfigMap"`

--- a/pkg/upgrade/control_plane_test.go
+++ b/pkg/upgrade/control_plane_test.go
@@ -343,6 +343,32 @@ func TestShouldSkipMachine(t *testing.T) {
 	}
 }
 
+func TestPatchMachine(t *testing.T) {
+	machine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cp-0-foobar",
+			Labels: map[string]string{
+				"hello": "world",
+			},
+			Annotations: map[string]string{
+				AnnotationMachineNameBase: "cp-0",
+			},
+		},
+	}
+
+	patch, err := jsonpatch.DecodePatch([]byte(`[{ "op": "remove", "path": "/metadata/labels/hello" }]`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	patched, err := patchMachine(machine, patch)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, map[string]string{}, patched.Labels)
+}
+
 func TestPatchRuntimeObject(t *testing.T) {
 	u := new(unstructured.Unstructured)
 	u.Object = map[string]interface{}{


### PR DESCRIPTION
This patch is predominantly meant to remove custom labels from existing
Machines during the rollout process. For example: removing a label that
uniquely identified the Machine that was used to initialize the cluster.